### PR TITLE
Refractor TensorBox Code

### DIFF
--- a/data_input.py
+++ b/data_input.py
@@ -1,0 +1,164 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools
+import json
+import logging
+import os
+import sys
+import random
+from random import shuffle
+
+import numpy as np
+
+import scipy as scp
+import scipy.misc
+
+from scipy.misc import imread, imresize
+
+import tensorflow as tf
+
+from utils.data_utils import (annotation_jitter, annotation_to_h5)
+from utils.annolist import AnnotationLib as AnnoLib
+from utils.rect import Rect
+
+
+def _rescale_boxes(current_shape, anno, target_height, target_width):
+    x_scale = target_width / float(current_shape[1])
+    y_scale = target_height / float(current_shape[0])
+    for r in anno.rects:
+        assert r.x1 < r.x2
+        r.x1 *= x_scale
+        r.x2 *= x_scale
+        assert r.x1 < r.x2
+        r.y1 *= y_scale
+        r.y2 *= y_scale
+    return anno
+
+
+def _load_idl_tf(idlfile, hypes, jitter):
+    """Take the idlfile and net configuration and create a generator
+    that outputs a jittered version of a random image from the annolist
+    that is mean corrected."""
+
+    annolist = AnnoLib.parse(idlfile)
+    annos = []
+    for anno in annolist:
+        anno.imageName = os.path.join(
+            os.path.dirname(os.path.realpath(idlfile)), anno.imageName)
+        annos.append(anno)
+    random.seed(0)
+    if hypes['data']['truncate_data']:
+        annos = annos[:10]
+    for epoch in itertools.count():
+        random.shuffle(annos)
+        for anno in annos:
+            im = imread(anno.imageName)
+            if im.shape[2] == 4:
+                im = im[:, :, :3]
+            if im.shape[0] != hypes["image_height"] or \
+               im.shape[1] != hypes["image_width"]:
+                if epoch == 0:
+                    anno = _rescale_boxes(im.shape, anno,
+                                          hypes["image_height"],
+                                          hypes["image_width"])
+                im = imresize(
+                    im, (hypes["image_height"], hypes["image_width"]),
+                    interp='cubic')
+            if jitter:
+                jitter_scale_min = 0.9
+                jitter_scale_max = 1.1
+                jitter_offset = 16
+                im, anno = annotation_jitter(
+                    im, anno, target_width=hypes["image_width"],
+                    target_height=hypes["image_height"],
+                    jitter_scale_min=jitter_scale_min,
+                    jitter_scale_max=jitter_scale_max,
+                    jitter_offset=jitter_offset)
+
+            boxes, flags = annotation_to_h5(hypes,
+                                            anno,
+                                            hypes["grid_width"],
+                                            hypes["grid_height"],
+                                            hypes["rnn_len"])
+
+            yield {"image": im, "boxes": boxes, "flags": flags}
+
+
+def _make_sparse(n, d):
+    v = np.zeros((d,), dtype=np.float32)
+    v[n] = 1.
+    return v
+
+
+def _load_data_gen(hypes, phase, jitter):
+    grid_size = hypes['grid_width'] * hypes['grid_height']
+
+    data = _load_idl_tf(hypes["data"]['%s_idl' % phase], hypes,
+                        jitter={'train': jitter, 'test': False}[phase])
+
+    for d in data:
+        output = {}
+        rnn_len = hypes["rnn_len"]
+        flags = d['flags'][0, :, 0, 0:rnn_len, 0]
+        boxes = np.transpose(d['boxes'][0, :, :, 0:rnn_len, 0], (0, 2, 1))
+        assert(flags.shape == (grid_size, rnn_len))
+        assert(boxes.shape == (grid_size, rnn_len, 4))
+
+        output['image'] = d['image']
+        confs = [[_make_sparse(int(detection), d=hypes['num_classes'])
+                 for detection in cell] for cell in flags]
+        output['confs'] = np.array(confs)
+        output['boxes'] = boxes
+        output['flags'] = flags
+
+        yield output
+
+
+def create_queues(hypes, phase):
+    """Create Queues."""
+    dtypes = [tf.float32, tf.float32, tf.float32]
+    grid_size = hypes['grid_width'] * hypes['grid_height']
+    shapes = ([hypes['image_height'], hypes['image_width'], 3],
+              [grid_size, hypes['rnn_len'], hypes['num_classes']],
+              [grid_size, hypes['rnn_len'], 4],)
+    capacity = 30
+    q = tf.FIFOQueue(capacity=capacity, dtypes=dtypes, shapes=shapes)
+    return q
+
+
+def start_enqueuing_threads(hypes, q, phase, sess, data_dir):
+    """Start enqueuing threads."""
+    shape = [hypes['arch']['image_height'], hypes['arch']['image_width'],
+             hypes['arch']['num_channels']]
+    image_pl = tf.placeholder(tf.float32)
+
+    # Labels
+    shape = [hypes['arch']['image_height'], hypes['arch']['image_width'],
+             hypes['arch']['num_classes']]
+    label_pl = tf.placeholder(tf.int32)
+
+    def make_feed(data):
+        image, label = data
+        return {image_pl: image, label_pl: label}
+
+    def enqueue_loop(sess, enqueue_op, phase, gen):
+        # infinity loop enqueueing data
+        for d in gen:
+            sess.run(enqueue_op, feed_dict=make_feed(d))
+
+    threads = []
+    enqueue_op = q.enqueue((image_pl, label_pl))
+    # gen = _make_data_gen(hypes, phase, data_dir)
+    # gen.next()
+    # sess.run(enqueue_op, feed_dict=make_feed(data))
+    if phase == 'val':
+        num_threads = 1
+    else:
+        num_threads = hypes["solver"]["threads"]
+    for i in range(num_threads):
+        threads.append(tf.train.threading.Thread(target=enqueue_loop,
+                                                 args=(sess, enqueue_op,
+                                                       phase, )))
+    threads[-1].start()

--- a/data_input.py
+++ b/data_input.py
@@ -153,3 +153,11 @@ def start_enqueuing_threads(hypes, q, phase, sess):
                                   args=(sess, enqueue_op, gen))
     t.daemon = True
     t.start()
+
+
+def inputs(hypes, q):
+
+    image, confidences, boxes = q.dequeue_many(hypes['batch_size'])
+    flags = tf.argmax(confidences, 3)
+
+    return image, (flags, confidences, boxes)

--- a/encoder.py
+++ b/encoder.py
@@ -7,15 +7,17 @@ import os
 
 from utils import googlenet_load
 
+encoder_net = []
 
-def inference(hypes, images, encoder_net, train=True):
+
+def inference(hypes, images, phase):
     # Load googlenet and returns the cnn_codes
 
-    # encoder_net = googlenet_load.init(hypes, config=config)
+    if phase == 'train':
+        encoder_net.append(googlenet_load.init(hypes))
 
-    # grid_size = hypes['grid_width'] * hypes['grid_height']
     input_mean = 117.
     images -= input_mean
-    cnn, early_feat, _ = googlenet_load.model(images, encoder_net, hypes)
+    cnn, early_feat, _ = googlenet_load.model(images, encoder_net[0], hypes)
 
     return cnn, early_feat, _

--- a/encoder.py
+++ b/encoder.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import os
+
+from utils import googlenet_load
+
+
+def inference(hypes, images, encoder_net, train=True):
+    # Load googlenet and returns the cnn_codes
+
+    # encoder_net = googlenet_load.init(hypes, config=config)
+
+    # grid_size = hypes['grid_width'] * hypes['grid_height']
+    input_mean = 117.
+    images -= input_mean
+    cnn, early_feat, _ = googlenet_load.model(images, encoder_net, hypes)
+
+    return cnn, early_feat, _

--- a/evaluate.py
+++ b/evaluate.py
@@ -10,7 +10,6 @@ from utils import googlenet_load
 from utils.annolist import AnnotationLib as al
 from utils.train_utils import add_rectangles, rescale_boxes
 
-import cv2
 import argparse
 
 def get_image_dir(args):

--- a/objective.py
+++ b/objective.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Trains, evaluates and saves the model network using a queue."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import ipdb
+
+import os
+import numpy as np
+import scipy as scp
+import random
+
+from utils import train_utils
+
+import tensorflow as tf
+
+try:
+    from tensorflow.models.rnn import rnn_cell
+except ImportError:
+    rnn_cell = tf.nn.rnn_cell
+
+
+def _deconv(x, output_shape, channels):
+    k_h = 2
+    k_w = 2
+    w = tf.get_variable('w_deconv',
+                        initializer=tf.random_normal_initializer(stddev=0.01),
+                        shape=[k_h, k_w, channels[1], channels[0]])
+    y = tf.nn.conv2d_transpose(x, w, output_shape, strides=[1, k_h, k_w, 1],
+                               padding='VALID')
+    return y
+
+
+def _rezoom(hyp, pred_boxes, early_feat, early_feat_channels,
+            w_offsets, h_offsets):
+    '''
+    Rezoom into a feature map at multiple interpolation points
+    in a grid.
+
+    If the predicted object center is at X, len(w_offsets) == 3,
+    and len(h_offsets) == 5,
+    the rezoom grid will look as follows:
+
+    [o o o]
+    [o o o]
+    [o X o]
+    [o o o]
+    [o o o]
+
+    Where each letter indexes into the feature map with bilinear interpolation
+    '''
+
+    grid_size = hyp['grid_width'] * hyp['grid_height']
+    outer_size = grid_size * hyp['batch_size']
+    indices = []
+    for w_offset in w_offsets:
+        for h_offset in h_offsets:
+            indices.append(train_utils.bilinear_select(hyp,
+                                                       pred_boxes,
+                                                       early_feat,
+                                                       early_feat_channels,
+                                                       w_offset, h_offset))
+
+    interp_indices = tf.concat(0, indices)
+    rezoom_features = train_utils.interp(early_feat,
+                                         interp_indices,
+                                         early_feat_channels)
+    rezoom_features_r = tf.reshape(rezoom_features,
+                                   [len(w_offsets) * len(h_offsets),
+                                    outer_size,
+                                    hyp['rnn_len'],
+                                    early_feat_channels])
+    rezoom_features_t = tf.transpose(rezoom_features_r, [1, 2, 0, 3])
+    return tf.reshape(rezoom_features_t,
+                      [outer_size,
+                       hyp['rnn_len'],
+                       len(w_offsets) * len(h_offsets) * early_feat_channels])
+
+
+def _build_lstm_inner(hyp, lstm_input):
+    '''
+    build lstm decoder
+    '''
+    lstm_cell = rnn_cell.BasicLSTMCell(hyp['lstm_size'], forget_bias=0.0)
+    if hyp['num_lstm_layers'] > 1:
+        lstm = rnn_cell.MultiRNNCell([lstm_cell] * hyp['num_lstm_layers'])
+    else:
+        lstm = lstm_cell
+
+    batch_size = hyp['batch_size'] * hyp['grid_height'] * hyp['grid_width']
+    state = tf.zeros([batch_size, lstm.state_size])
+
+    outputs = []
+    with tf.variable_scope(
+            'RNN', initializer=tf.random_uniform_initializer(-0.1, 0.1)):
+        for time_step in range(hyp['rnn_len']):
+            if time_step > 0:
+                tf.get_variable_scope().reuse_variables()
+            output, state = lstm(lstm_input, state)
+            outputs.append(output)
+    return outputs
+
+
+def _build_overfeat_inner(hyp, lstm_input):
+    '''
+    build simple overfeat decoder
+    '''
+    if hyp['rnn_len'] > 1:
+        raise ValueError('rnn_len > 1 only supported with use_lstm == True')
+    outputs = []
+    initializer = tf.random_uniform_initializer(-0.1, 0.1)
+    with tf.variable_scope('Overfeat', initializer=initializer):
+        w = tf.get_variable('ip', shape=[1024, hyp['lstm_size']])
+        outputs.append(tf.matmul(lstm_input, w))
+    return outputs
+
+
+def decoder(hyp, logits, phase):
+    """Apply decoder to the logits.
+
+    Computation which decode CNN boxes.
+    The output can be interpreted as bounding Boxes.
+
+
+    Args:
+      logits: Logits tensor, output von encoder
+
+    Return:
+      decoded_logits: values which can be interpreted as bounding boxes
+    """
+    cnn, early_feat, _ = logits
+
+    grid_size = hyp['grid_width'] * hyp['grid_height']
+    outer_size = grid_size * hyp['batch_size']
+    reuse = {'train': None, 'test': True}[phase]
+
+    early_feat_channels = hyp['early_feat_channels']
+    early_feat = early_feat[:, :, :, :early_feat_channels]
+
+    if hyp['deconv']:
+        size = 3
+        stride = 2
+        pool_size = 5
+
+        with tf.variable_scope("deconv", reuse=reuse):
+            initializer = tf.random_normal_initializer(stddev=0.01)
+            w = tf.get_variable('conv_pool_w', shape=[size, size, 1024, 1024],
+                                initializer=initializer)
+            cnn_s = tf.nn.conv2d(cnn, w, strides=[1, stride, stride, 1],
+                                 padding='SAME')
+            cnn_s_pool = tf.nn.avg_pool(cnn_s[:, :, :, :256],
+                                        ksize=[1, pool_size, pool_size, 1],
+                                        strides=[1, 1, 1, 1], padding='SAME')
+
+            cnn_s_with_pool = tf.concat(3, [cnn_s_pool, cnn_s[:, :, :, 256:]])
+            output_shape = [hyp['batch_size'], hyp['grid_height'],
+                            hyp['grid_width'], 256]
+            cnn_deconv = _deconv(
+                cnn_s_with_pool, output_shape=output_shape,
+                channels=[1024, 256])
+            cnn = tf.concat(3, (cnn_deconv, cnn[:, :, :, 256:]))
+
+    elif hyp['avg_pool_size'] > 1:
+        pool_size = hyp['avg_pool_size']
+        cnn1 = cnn[:, :, :, :700]
+        cnn2 = cnn[:, :, :, 700:]
+        cnn2 = tf.nn.avg_pool(cnn2, ksize=[1, pool_size, pool_size, 1],
+                              strides=[1, 1, 1, 1], padding='SAME')
+        cnn = tf.concat(3, [cnn1, cnn2])
+
+    num_ex = hyp['batch_size'] * hyp['grid_width'] * hyp['grid_height']
+
+    cnn = tf.reshape(cnn, [num_ex, 1024])
+    initializer = tf.random_uniform_initializer(-0.1, 0.1)
+    with tf.variable_scope('decoder', reuse=reuse, initializer=initializer):
+        scale_down = 0.01
+        lstm_input = tf.reshape(
+            cnn * scale_down, (hyp['batch_size'] * grid_size, 1024))
+        if hyp['use_lstm']:
+            lstm_outputs = _build_lstm_inner(hyp, lstm_input)
+        else:
+            lstm_outputs = _build_overfeat_inner(hyp, lstm_input)
+
+        pred_boxes = []
+        pred_logits = []
+        for k in range(hyp['rnn_len']):
+            output = lstm_outputs[k]
+            if phase == 'train':
+                output = tf.nn.dropout(output, 0.5)
+            box_weights = tf.get_variable('box_ip%d' % k,
+                                          shape=(hyp['lstm_size'], 4))
+            conf_weights = tf.get_variable('conf_ip%d' % k,
+                                           shape=(hyp['lstm_size'],
+                                                  hyp['num_classes']))
+
+            pred_boxes_step = tf.reshape(tf.matmul(output, box_weights) * 50,
+                                         [outer_size, 1, 4])
+
+            pred_boxes.append(pred_boxes_step)
+            pred_logits.append(tf.reshape(tf.matmul(output, conf_weights),
+                                          [outer_size, 1, hyp['num_classes']]))
+
+        pred_boxes = tf.concat(1, pred_boxes)
+        pred_logits = tf.concat(1, pred_logits)
+        pred_logits_squash = tf.reshape(pred_logits,
+                                        [outer_size * hyp['rnn_len'],
+                                         hyp['num_classes']])
+        pred_confidences_squash = tf.nn.softmax(pred_logits_squash)
+        pred_confidences = tf.reshape(pred_confidences_squash,
+                                      [outer_size, hyp['rnn_len'],
+                                       hyp['num_classes']])
+
+        if hyp['use_rezoom']:
+            pred_confs_deltas = []
+            pred_boxes_deltas = []
+            w_offsets = hyp['rezoom_w_coords']
+            h_offsets = hyp['rezoom_h_coords']
+            num_offsets = len(w_offsets) * len(h_offsets)
+            rezoom_features = _rezoom(
+                hyp, pred_boxes, early_feat, early_feat_channels,
+                w_offsets, h_offsets)
+            if phase == 'train':
+                rezoom_features = tf.nn.dropout(rezoom_features, 0.5)
+            for k in range(hyp['rnn_len']):
+                delta_features = tf.concat(
+                    1, [lstm_outputs[k], rezoom_features[:, k, :] / 1000.])
+                dim = 128
+                shape = [hyp['lstm_size'] + early_feat_channels * num_offsets,
+                         dim]
+                delta_weights1 = tf.get_variable('delta_ip1%d' % k,
+                                                 shape=shape)
+                # TODO: add dropout here ?
+                ip1 = tf.nn.relu(tf.matmul(delta_features, delta_weights1))
+                if phase == 'train':
+                    ip1 = tf.nn.dropout(ip1, 0.5)
+                delta_confs_weights = tf.get_variable(
+                    'delta_ip2%d' % k,
+                    shape=[dim, hyp['num_classes']])
+                if hyp['reregress']:
+                    delta_boxes_weights = tf.get_variable(
+                        'delta_ip_boxes%d' % k,
+                        shape=[dim, 4])
+                    rere_feature = tf.matmul(ip1, delta_boxes_weights) * 5
+                    pred_boxes_deltas.append(tf.reshape(rere_feature,
+                                                        [outer_size, 1, 4]))
+                scale = hyp.get('rezoom_conf_scale', 50)
+                feature2 = tf.matmul(ip1, delta_confs_weights) * scale
+                pred_confs_deltas.append(tf.reshape(feature2,
+                                                    [outer_size, 1,
+                                                     hyp['num_classes']]))
+            pred_confs_deltas = tf.concat(1, pred_confs_deltas)
+            if hyp['reregress']:
+                pred_boxes_deltas = tf.concat(1, pred_boxes_deltas)
+            logits = pred_boxes, pred_logits, pred_confidences,\
+                pred_confs_deltas, pred_boxes_deltas
+
+            return logits
+
+    return pred_boxes, pred_logits, pred_confidences
+
+
+def loss(hypes, decoded_logits, labels, phase):
+    """Calculate the loss from the logits and the labels.
+
+    Args:
+      decoded_logits: output of decoder
+      labels: Labels tensor; Output from data_input
+
+    Returns:
+      loss: Loss tensor of type float.
+    """
+
+    flags, confidences, boxes = labels
+
+    if hypes['use_rezoom']:
+        (pred_boxes, pred_logits, pred_confidences,
+         pred_confs_deltas, pred_boxes_deltas) = decoded_logits
+    else:
+        pred_boxes, pred_logits, pred_confidences = decoded_logits
+
+    grid_size = hypes['grid_width'] * hypes['grid_height']
+    outer_size = grid_size * hypes['batch_size']
+
+    with tf.variable_scope('decoder',
+                           reuse={'train': None, 'test': True}[phase]):
+        outer_boxes = tf.reshape(boxes, [outer_size, hypes['rnn_len'], 4])
+        outer_flags = tf.cast(
+            tf.reshape(flags, [outer_size, hypes['rnn_len']]), 'int32')
+        if hypes['use_lstm']:
+            assignments, classes, perm_truth, pred_mask = (
+                tf.user_ops.hungarian(pred_boxes, outer_boxes, outer_flags,
+                                      hypes['solver']['hungarian_iou']))
+        else:
+            classes = tf.reshape(flags, (outer_size, 1))
+            perm_truth = tf.reshape(outer_boxes, (outer_size, 1, 4))
+            pred_mask = tf.reshape(
+                tf.cast(tf.greater(classes, 0), 'float32'), (outer_size, 1, 1))
+        true_classes = tf.reshape(tf.cast(tf.greater(classes, 0), 'int64'),
+                                  [outer_size * hypes['rnn_len']])
+        pred_logit_r = tf.reshape(pred_logits,
+                                  [outer_size * hypes['rnn_len'],
+                                   hypes['num_classes']])
+
+    grid_size = hypes['grid_width'] * hypes['grid_height']
+    outer_size = grid_size * hypes['batch_size']
+
+    cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+        pred_logit_r, true_classes)
+
+    cross_entropy_sum = (tf.reduce_sum(cross_entropy))
+
+    head = hypes['solver']['head_weights']
+    confidences_loss = cross_entropy_sum / outer_size * head[0]
+    residual = tf.reshape(perm_truth - pred_boxes * pred_mask,
+                          [outer_size, hypes['rnn_len'], 4])
+
+    boxes_loss = tf.reduce_sum(tf.abs(residual)) / outer_size * head[1]
+    if hypes['use_rezoom']:
+        if hypes['rezoom_change_loss'] == 'center':
+            error = (perm_truth[:, :, 0:2] - pred_boxes[:, :, 0:2]) \
+                / tf.maximum(perm_truth[:, :, 2:4], 1.)
+            square_error = tf.reduce_sum(tf.square(error), 2)
+            inside = tf.reshape(tf.to_int64(
+                tf.logical_and(tf.less(square_error, 0.2**2),
+                               tf.greater(classes, 0))), [-1])
+        elif hypes['rezoom_change_loss'] == 'iou':
+            pred_boxes_flat = tf.reshape(pred_boxes, [-1, 4])
+            perm_truth_flat = tf.reshape(perm_truth, [-1, 4])
+            iou = train_utils.iou(train_utils.to_x1y1x2y2(pred_boxes_flat),
+                                  train_utils.to_x1y1x2y2(perm_truth_flat))
+            inside = tf.reshape(tf.to_int64(tf.greater(iou, 0.5)), [-1])
+        else:
+            assert not hypes['rezoom_change_loss']
+            inside = tf.reshape(tf.to_int64((tf.greater(classes, 0))), [-1])
+        new_confs = tf.reshape(
+            pred_confs_deltas, [outer_size * hypes['rnn_len'],
+                                hypes['num_classes']])
+
+        cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+            new_confs, inside)
+
+        delta_confs_loss = tf.reduce_sum(cross_entropy) \
+            / outer_size * hypes['solver']['head_weights'][0] * 0.1
+
+        pred_logits_squash = tf.reshape(new_confs,
+                                        [outer_size * hypes['rnn_len'],
+                                         hypes['num_classes']])
+        pred_confidences_squash = tf.nn.softmax(pred_logits_squash)
+        pred_confidences = tf.reshape(pred_confidences_squash,
+                                      [outer_size, hypes['rnn_len'],
+                                       hypes['num_classes']])
+        loss = confidences_loss + boxes_loss + delta_confs_loss
+        if hypes['reregress']:
+            delta_unshaped = perm_truth - (pred_boxes + pred_boxes_deltas)
+
+            delta_residual = tf.reshape(delta_unshaped * pred_mask,
+                                        [outer_size, hypes['rnn_len'], 4])
+            sqrt_delta = tf.minimum(tf.square(delta_residual), 10. ** 2)
+            delta_boxes_loss = (tf.reduce_sum(sqrt_delta) /
+                                outer_size * head[1] * 0.03)
+            boxes_loss = delta_boxes_loss
+
+            tf.histogram_summary(
+                phase + '/delta_hist0_x', pred_boxes_deltas[:, 0, 0])
+            tf.histogram_summary(
+                phase + '/delta_hist0_y', pred_boxes_deltas[:, 0, 1])
+            tf.histogram_summary(
+                phase + '/delta_hist0_w', pred_boxes_deltas[:, 0, 2])
+            tf.histogram_summary(
+                phase + '/delta_hist0_h', pred_boxes_deltas[:, 0, 3])
+            loss += delta_boxes_loss
+    else:
+        loss = confidences_loss + boxes_loss
+
+    return loss, confidences_loss, boxes_loss
+
+
+def evaluation(hyp, images, labels, decoded_logits, losses, global_step):
+
+    loss, accuracy, confidences_loss, boxes_loss = {}, {}, {}, {}
+
+    # Estimating Accuracy
+    for phase in ['train', 'test']:
+
+        flags, confidences, boxes = labels[phase]
+        loss[phase], confidences_loss[phase], boxes_loss[phase] = losses[phase]
+
+        if hyp['use_rezoom']:
+            (pred_boxes, pred_logits, pred_confidences,
+             pred_confs_deltas, pred_boxes_deltas) = decoded_logits[phase]
+        else:
+            pred_boxes, pred_logits, pred_confidences = decoded_logits[phase]
+
+        grid_size = hyp['grid_width'] * hyp['grid_height']
+
+        pred_confidences_r = tf.reshape(
+            pred_confidences,
+            [hyp['batch_size'], grid_size, hyp['rnn_len'], hyp['num_classes']])
+        pred_boxes_r = tf.reshape(
+            pred_boxes, [hyp['batch_size'], grid_size, hyp['rnn_len'], 4])
+
+        # Set up summary operations for tensorboard
+        a = tf.equal(tf.argmax(confidences[:, :, 0, :], 2), tf.argmax(
+            pred_confidences_r[:, :, 0, :], 2))
+        accuracy[phase] = tf.reduce_mean(
+            tf.cast(a, 'float32'), name=phase+'/accuracy')
+
+    # Writing Metrics to Tensorboard
+
+    moving_avg = tf.train.ExponentialMovingAverage(0.95)
+    smooth_op = moving_avg.apply([accuracy['train'], accuracy['test'],
+                                  confidences_loss[
+                                      'train'], boxes_loss['train'],
+                                  confidences_loss[
+                                      'test'], boxes_loss['test'],
+                                  ])
+
+    for p in ['train', 'test']:
+        tf.scalar_summary('%s/accuracy' % p, accuracy[p])
+        tf.scalar_summary('%s/accuracy/smooth' %
+                          p, moving_avg.average(accuracy[p]))
+        tf.scalar_summary("%s/confidences_loss" % p, confidences_loss[p])
+        tf.scalar_summary("%s/confidences_loss/smooth" % p,
+                          moving_avg.average(confidences_loss[p]))
+        tf.scalar_summary("%s/regression_loss" % p, boxes_loss[p])
+        tf.scalar_summary("%s/regression_loss/smooth" % p,
+                          moving_avg.average(boxes_loss[p]))
+
+    test_image = images['test']
+    # show ground truth to verify labels are correct
+    test_true_confidences = confidences[0, :, :, :]
+    test_true_boxes = boxes[0, :, :, :]
+
+    # show predictions to visualize training progress
+    test_pred_confidences = pred_confidences_r[0, :, :, :]
+    test_pred_boxes = pred_boxes_r[0, :, :, :]
+
+    def log_image(np_img, np_confidences, np_boxes, np_global_step,
+                  pred_or_true):
+
+        merged = train_utils.add_rectangles(hyp, np_img, np_confidences,
+                                            np_boxes,
+                                            use_stitching=True,
+                                            rnn_len=hyp['rnn_len'])[0]
+
+        num_images = 10
+        filename = '%s_%s.jpg' % \
+            ((np_global_step / hyp['logging']['display_iter'])
+                % num_images, pred_or_true)
+        img_path = os.path.join(hyp['save_dir'], filename)
+        scp.misc.imsave(img_path, merged)
+        return merged
+
+    pred_log_img = tf.py_func(log_image,
+                              [test_image, test_pred_confidences,
+                               test_pred_boxes, global_step, 'pred'],
+                              [tf.float32])
+    true_log_img = tf.py_func(log_image,
+                              [test_image, test_true_confidences,
+                               test_true_boxes, global_step, 'true'],
+                              [tf.float32])
+    tf.image_summary(phase + '/pred_boxes', tf.pack(pred_log_img),
+                     max_images=10)
+    tf.image_summary(phase + '/true_boxes', tf.pack(true_log_img),
+                     max_images=10)
+
+    return accuracy, smooth_op

--- a/objective.py
+++ b/objective.py
@@ -375,7 +375,7 @@ def loss(hypes, decoded_logits, labels, phase):
     else:
         loss = confidences_loss + boxes_loss
 
-    return loss, confidences_loss, boxes_loss
+    return pred_boxes, pred_confidences, loss, confidences_loss, boxes_loss
 
 
 def evaluation(hyp, images, labels, decoded_logits, losses, global_step):

--- a/objective.py
+++ b/objective.py
@@ -388,11 +388,14 @@ def evaluation(hyp, images, labels, decoded_logits, losses, global_step):
         flags, confidences, boxes = labels[phase]
         loss[phase], confidences_loss[phase], boxes_loss[phase] = losses[phase]
 
+        pred_confidences, pred_boxes = decoded_logits[phase]
+        """
         if hyp['use_rezoom']:
             (pred_boxes, pred_logits, pred_confidences,
              pred_confs_deltas, pred_boxes_deltas) = decoded_logits[phase]
         else:
             pred_boxes, pred_logits, pred_confidences = decoded_logits[phase]
+        """
 
         grid_size = hyp['grid_width'] * hyp['grid_height']
 
@@ -447,10 +450,12 @@ def evaluation(hyp, images, labels, decoded_logits, losses, global_step):
                                             rnn_len=hyp['rnn_len'])[0]
 
         num_images = 10
+
         filename = '%s_%s.jpg' % \
-            ((np_global_step / hyp['logging']['display_iter'])
+            ((np_global_step // hyp['logging']['display_iter'])
                 % num_images, pred_or_true)
         img_path = os.path.join(hyp['save_dir'], filename)
+
         scp.misc.imsave(img_path, merged)
         return merged
 

--- a/optimizer.py
+++ b/optimizer.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import sys
+import tensorflow as tf
+
+
+def training(hypes, loss, global_step, learning_rate):
+    """Sets up the training Ops.
+
+    Creates a summarizer to track the loss over time in TensorBoard.
+
+    Creates an optimizer and applies the gradients to all trainable variables.
+
+    The Op returned by this function is what must be passed to the
+    `sess.run()` call to cause the model to train.
+
+    Args:
+      loss: Loss tensor, from loss().
+      global_step: Integer Variable counting the number of training steps
+        processed.
+      learning_rate: The learning rate to use for gradient descent.
+
+    Returns:
+      train_op: The Op for training.
+    """
+    # Add a scalar summary for the snapshot loss.
+    sol = hypes["solver"]
+    with tf.name_scope('training'):
+
+        tvars = tf.trainable_variables()
+        if hypes['clip_norm'] <= 0:
+            grads = tf.gradients(loss, tvars)
+        else:
+            grads, norm = tf.clip_by_global_norm(tf.gradients(loss, tvars),
+                                                 hypes['clip_norm'])
+
+        to_opt = zip(grads, tvars)
+
+        if sol['opt'] == 'RMS':
+            opt = tf.train.RMSPropOptimizer(learning_rate=learning_rate,
+                                            decay=0.9, epsilon=sol['epsilon'])
+        elif sol['opt'] == 'Adam':
+            opt = tf.train.AdamOptimizer(learning_rate=learning_rate,
+                                         epsilon=sol['epsilon'])
+        elif sol['opt'] == 'SGD':
+            lr = learning_rate
+            opt = tf.train.GradientDescentOptimizer(learning_rate=lr)
+        else:
+            raise ValueError('Unrecognized opt type')
+
+        train_op = opt.apply_gradients(to_opt, global_step=global_step)
+
+    return train_op

--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ np.random.seed(0)
 
 import data_input
 import encoder
-# import optimizer
+import optimizer
 
 from utils import train_utils, googlenet_load
 
@@ -340,7 +340,7 @@ def build(H, q):
         if phase == 'train':
             global_step = tf.Variable(0, trainable=False)
 
-            train_op = optimizer.training(H, loss,
+            train_op = optimizer.training(H, loss['train'],
                                           global_step, learning_rate)
 
         elif phase == 'test':

--- a/train.py
+++ b/train.py
@@ -52,13 +52,8 @@ def build(hypes, q):
         decoded_logits[phase] = objective.decoder(hypes, logits, phase)
 
         # Compute losses
-        pred_boxes, pred_confidences, loss, confidences_loss, boxes_loss \
-            = objective.loss(hypes, decoded_logits[phase],
-                             labels[phase], phase)
-
-        # Resummaryze tensors
-        losses[phase] = loss, confidences_loss, boxes_loss
-        decoded_logits[phase] = pred_confidences, pred_boxes
+        losses[phase] = objective.loss(hypes, decoded_logits[phase],
+                                       labels[phase], phase)
 
     total_loss = losses['train'][0]
     global_step = tf.Variable(0, trainable=False)

--- a/train.py
+++ b/train.py
@@ -20,7 +20,7 @@ random.seed(0)
 np.random.seed(0)
 
 import data_input
-# import encoder
+import encoder
 # import optimizer
 
 from utils import train_utils, googlenet_load
@@ -123,9 +123,8 @@ def build_forward(H, x, googlenet, phase, reuse):
 
     grid_size = H['grid_width'] * H['grid_height']
     outer_size = grid_size * H['batch_size']
-    input_mean = 117.
-    x -= input_mean
-    cnn, early_feat, _ = googlenet_load.model(x, googlenet, H)
+
+    cnn, early_feat, _ = encoder.inference(H, x, googlenet)
     early_feat_channels = H['early_feat_channels']
     early_feat = early_feat[:, :, :, :early_feat_channels]
     

--- a/train.py
+++ b/train.py
@@ -141,14 +141,8 @@ def build_forward_backward(H, x, googlenet, phase, boxes, flags):
     decoded_logits = build_forward(H, x, googlenet, phase, reuse)
     labels = flags, None, boxes
 
-    losses = objective.loss(H, decoded_logits, labels, phase)
-
-    loss, confidences_loss, boxes_loss = losses
-    if H['use_rezoom']:
-        (pred_boxes, pred_logits, pred_confidences,
-         pred_confs_deltas, pred_boxes_deltas) = decoded_logits
-    else:
-        pred_boxes, pred_logits, pred_confidences = decoded_logits
+    pred_boxes, pred_confidences, loss, confidences_loss, boxes_loss \
+     = objective.loss(H, decoded_logits, labels, phase)
 
 
     return pred_boxes, pred_confidences, loss, confidences_loss, boxes_loss

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,5 +1,4 @@
 import os
-import cv2
 import re
 import sys
 import argparse

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -7,6 +7,9 @@ import numpy as np
 import copy
 import annolist.AnnotationLib as al
 
+import scipy as scp
+import scipy.misc
+
 def annotation_to_h5(H, a, cell_width, cell_height, max_len):
     region_size = H['region_size']
     assert H['region_size'] == H['image_height'] / H['grid_height']
@@ -110,7 +113,7 @@ def annotation_jitter(I, a_in, min_box_width=20, jitter_scale_min=0.9, jitter_sc
             for p in r.point:
                 p.x = I.shape[1] - p.x
 
-    I1 = cv2.resize(I, None, fx=jitter_scale, fy=jitter_scale, interpolation = cv2.INTER_CUBIC)
+    I1 = scp.misc.imresize(I, jitter_scale, interp='cubic')
 
     jitter_offset_x = np.random.random_integers(-jitter_offset, jitter_offset)
     jitter_offset_y = np.random.random_integers(-jitter_offset, jitter_offset)

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -2,10 +2,11 @@ import numpy as np
 import random
 import json
 import os
-import cv2
 import itertools
 from scipy.misc import imread, imresize
 import tensorflow as tf
+
+from PIL import Image, ImageDraw
 
 from data_utils import (annotation_jitter, annotation_to_h5)
 from utils.annolist import AnnotationLib as al
@@ -89,8 +90,20 @@ def load_data_gen(H, phase, jitter):
         output['confs'] = np.array([[make_sparse(int(detection), d=H['num_classes']) for detection in cell] for cell in flags])
         output['boxes'] = boxes
         output['flags'] = flags
-        
+
         yield output
+
+
+def _draw_rect(draw, rect, color):
+    left = rect.cx-int(rect.width/2)
+    bottom = rect.cy+int(rect.height/2)
+    right = rect.cx+int(rect.width/2)
+    top = rect.cy-int(rect.height/2)
+    rect_cords = ((left, top), (left, bottom),
+                  (right, bottom), (right, top),
+                  (left, top))
+    draw.line(rect_cords, fill=color, width=2)
+
 
 def add_rectangles(H, orig_image, confidences, boxes, use_stitching=False, rnn_len=1, min_conf=0.1, show_removed=True, tau=0.25):
     image = np.copy(orig_image[0])
@@ -127,14 +140,13 @@ def add_rectangles(H, orig_image, confidences, boxes, use_stitching=False, rnn_l
 
 
     pairs = [(all_rects_r, (255, 0, 0)), (acc_rects, (0, 255, 0))]
+    im = Image.fromarray(image.astype('uint8'))
+    draw = ImageDraw.Draw(im)
     for rect_set, color in pairs:
         for rect in rect_set:
             if rect.confidence > min_conf:
-                cv2.rectangle(image,
-                    (rect.cx-int(rect.width/2), rect.cy-int(rect.height/2)),
-                    (rect.cx+int(rect.width/2), rect.cy+int(rect.height/2)),
-                    color,
-                    2)
+                _draw_rect(draw, rect, color)
+    image = np.array(im).astype('float32')
 
     rects = []
     for rect in acc_rects:

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -12,87 +12,6 @@ from data_utils import (annotation_jitter, annotation_to_h5)
 from utils.annolist import AnnotationLib as al
 from rect import Rect
 
-def rescale_boxes(current_shape, anno, target_height, target_width):
-    x_scale = target_width / float(current_shape[1])
-    y_scale = target_height / float(current_shape[0])
-    for r in anno.rects:
-        assert r.x1 < r.x2
-        r.x1 *= x_scale
-        r.x2 *= x_scale
-        assert r.x1 < r.x2
-        r.y1 *= y_scale
-        r.y2 *= y_scale
-    return anno
-
-def load_idl_tf(idlfile, H, jitter):
-    """Take the idlfile and net configuration and create a generator
-    that outputs a jittered version of a random image from the annolist
-    that is mean corrected."""
-
-    annolist = al.parse(idlfile)
-    annos = []
-    for anno in annolist:
-        anno.imageName = os.path.join(
-            os.path.dirname(os.path.realpath(idlfile)), anno.imageName)
-        annos.append(anno)
-    random.seed(0)
-    if H['data']['truncate_data']:
-        annos = annos[:10]
-    for epoch in itertools.count():
-        random.shuffle(annos)
-        for anno in annos:
-            I = imread(anno.imageName)
-            if I.shape[2] == 4:
-                I = I[:, :, :3]
-            if I.shape[0] != H["image_height"] or I.shape[1] != H["image_width"]:
-                if epoch == 0:
-                    anno = rescale_boxes(I.shape, anno, H["image_height"], H["image_width"])
-                I = imresize(I, (H["image_height"], H["image_width"]), interp='cubic')
-            if jitter:
-                jitter_scale_min=0.9
-                jitter_scale_max=1.1
-                jitter_offset=16
-                I, anno = annotation_jitter(I,
-                                            anno, target_width=H["image_width"],
-                                            target_height=H["image_height"],
-                                            jitter_scale_min=jitter_scale_min,
-                                            jitter_scale_max=jitter_scale_max,
-                                            jitter_offset=jitter_offset)
-
-            boxes, flags = annotation_to_h5(H,
-                                            anno,
-                                            H["grid_width"],
-                                            H["grid_height"],
-                                            H["rnn_len"])
-
-            yield {"image": I, "boxes": boxes, "flags": flags}
-
-def make_sparse(n, d):
-    v = np.zeros((d,), dtype=np.float32)
-    v[n] = 1.
-    return v
-
-def load_data_gen(H, phase, jitter):
-    grid_size = H['grid_width'] * H['grid_height']
-
-    data = load_idl_tf(H["data"]['%s_idl' % phase], H, jitter={'train': jitter, 'test': False}[phase])
-
-    for d in data:
-        output = {}
-        
-        rnn_len = H["rnn_len"]
-        flags = d['flags'][0, :, 0, 0:rnn_len, 0]
-        boxes = np.transpose(d['boxes'][0, :, :, 0:rnn_len, 0], (0, 2, 1))
-        assert(flags.shape == (grid_size, rnn_len))
-        assert(boxes.shape == (grid_size, rnn_len, 4))
-
-        output['image'] = d['image']
-        output['confs'] = np.array([[make_sparse(int(detection), d=H['num_classes']) for detection in cell] for cell in flags])
-        output['boxes'] = boxes
-        output['flags'] = flags
-
-        yield output
-
 
 def _draw_rect(draw, rect, color):
     left = rect.cx-int(rect.width/2)
@@ -146,6 +65,7 @@ def add_rectangles(H, orig_image, confidences, boxes, use_stitching=False, rnn_l
         for rect in rect_set:
             if rect.confidence > min_conf:
                 _draw_rect(draw, rect, color)
+
     image = np.array(im).astype('float32')
 
     rects = []


### PR DESCRIPTION
This pull request retractors the training code. It makes the whole code pep8 compatibly and splits the model building in meaningful parts. The refactoring make the code much more readable and understandable for outsiders.

The model building process is split into the following functions:
1. data_input.inputs
2. encoder.inference
3. objective.decoder
4. objective.loss
5. optimizer.training
6. objective.evaluation

Additionally, the code is now split into different files. This has the advantage, that it is easier to test new models. One could for example manipulate the encoder (use ResNet) or the loss/decoder while keeping the other parts constant.