### PR TITLE
Skipped greyscale in training images

### DIFF
--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -41,6 +41,9 @@ def load_idl_tf(idlfile, H, jitter):
         random.shuffle(annos)
         for anno in annos:
             I = imread(anno.imageName)
+	    #Skip Greyscale images
+            if len(I.shape) < 3:
+                continue	    
             if I.shape[2] == 4:
                 I = I[:, :, :3]
             if I.shape[0] != H["image_height"] or I.shape[1] != H["image_width"]:


### PR DESCRIPTION
Getting error with greyscale images, [issue](https://github.com/Russell91/TensorBox/issues/72)


While running training for Reinspect, I got error in reading  [greyscale images](https://github.com/Russell91/TensorBox/blob/master/utils/train_utils.py#L43)
```
python train.py --hypes hypes/lstm_rezoom.json --gpu 0 --logdir output
```
Image properties are as follows:
```
Image Name  /home/dave/DeepLearning/TensorBox/data/cars_train/08144.jpg
Image Shape  (683, 883)
```

The error trace is as follows:
````
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "train.py", line 439, in thread_loop
    for d in gen:
  File "/home/dave/DeepLearning/TensorBox/utils/train_utils.py", line 83, in load_data_gen
    for d in data:
  File "/home/dave/DeepLearning/TensorBox/utils/train_utils.py", line 48, in load_idl_tf
    if I.shape[2] == 4:
IndexError: tuple index out of range
```

The error can be fixed by skipping the greyscale training images. 
