### PR TITLE
Added state_is_tuple as False to fix issue with training on GPU

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,9 +29,10 @@ def build_lstm_inner(H, lstm_input):
     '''
     build lstm decoder
     '''
-    lstm_cell = rnn_cell.BasicLSTMCell(H['lstm_size'], forget_bias=0.0)
+    #Added state_is_tuple as False to enable running on GPUs
+    lstm_cell = rnn_cell.BasicLSTMCell(H['lstm_size'], forget_bias=0.0, state_is_tuple=False) 
     if H['num_lstm_layers'] > 1:
-        lstm = rnn_cell.MultiRNNCell([lstm_cell] * H['num_lstm_layers'])
+        lstm = rnn_cell.MultiRNNCell([lstm_cell] * H['num_lstm_layers'], state_is_tuple=False)
     else:
         lstm = lstm_cell
 


### PR DESCRIPTION
This pull request is to fix the [error with GPU training](https://github.com/Russell91/TensorBox/issues/59) caused by state_is_tuple flag.
States in newer versions of TensorFlow (from 0.10.0) are created as tuples, however in TensorBox uses concatenated states and that causes an error while running on GPUs. 