### PR TITLE
Make sure rect indices are valid

### DIFF
--- a/utils/stitch_rects.cpp
+++ b/utils/stitch_rects.cpp
@@ -85,20 +85,22 @@ void filter_rects(const vector<vector<vector<Rect> > >& all_rects,
 
       vector<int> bad;
       for (int k = 0; k < (int)assignment.size(); ++k) {
-        Rect& c = current_rects[k];
-        Rect& a = relevant_rects[assignment[k]];
-        if (c.confidence_ > max_threshold) {
-          bad.push_back(k);
-          continue;
-        }
-        if (c.overlaps(a, tau)) {
-          if (c.confidence_ > a.confidence_ && c.iou(a) > 0.7) {
-            c.true_confidence_ = a.confidence_;
-            stitched_rects->erase(std::find(stitched_rects->begin(), stitched_rects->end(), a));
-          } else {
+        if (k < current_rects.size() && assignment[k] < relevant_rects.size()) {
+          Rect& c = current_rects[k];
+          Rect& a = relevant_rects[assignment[k]];
+          if (c.confidence_ > max_threshold) {
             bad.push_back(k);
+            continue;
           }
-        } 
+          if (c.overlaps(a, tau)) {
+            if (c.confidence_ > a.confidence_ && c.iou(a) > 0.7) {
+              c.true_confidence_ = a.confidence_;
+              stitched_rects->erase(std::find(stitched_rects->begin(), stitched_rects->end(), a));
+            } else {
+              bad.push_back(k);
+            }
+          }
+        }
       }
 
       for (int k = 0; k < (int)current_rects.size(); ++k) {


### PR DESCRIPTION
There seems to be a small problem with the rectangle stitching logic in [this for loop](https://github.com/Russell91/TensorBox/blob/4a6d32330a3e52cc25a474da6038ac2b0d3019ce/utils/stitch_rects.cpp#L87-L102). Running a slightly modified version of TensorBox, I was getting a segfault at what seem to be non-deterministic times.

For me, the size of `current_rects` was sometimes smaller than the size of `assignments`, but you could also run into a problem with `assignments[k]` being out of bounds for `relevant_rects` since `num_pred` is the max of the two sizes.

The solution: just check to make sure the indices are in bounds before possibly adding a rect to the `bad` vector.

This seems to be working for me, although since the segfaults came at random times I can't totally rule out that the problem still exists.