### PR TITLE
imports train_utils earlier

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from utils import train_utils, googlenet_load
 import json
 import tensorflow.contrib.slim as slim
 import datetime
@@ -19,8 +20,6 @@ from tensorflow.python.ops import array_ops
 
 random.seed(0)
 np.random.seed(0)
-
-from utils import train_utils, googlenet_load
 
 @ops.RegisterGradient("Hungarian")
 def _hungarian_grad(op, *args):


### PR DESCRIPTION
Imports train_utils at the beginning so that it can load heavier stuff(i.e cv2) in the memory.
See #113 for details.